### PR TITLE
Update to IDs to make it easier to locate output for a framework

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -123,7 +123,7 @@ SWIG_WEBUI_OBJ = $(MASTER_SWIG_WEBUI_OBJ) $(SLAVE_SWIG_WEBUI_OBJ)
 COMMON_OBJ = common/fatal.o messaging/messages.o common/lock.o		\
 	     detector/detector.o common/params.o			\
 	     detector/url_processor.o configurator/configurator.o	\
-	     common/string_utils.o common/logging.o
+	     common/string_utils.o common/logging.o common/date_utils.o
 
 ifeq ($(WITH_ZOOKEEPER),1)
   COMMON_OBJ += detector/zookeeper.o

--- a/src/local/local.cpp
+++ b/src/local/local.cpp
@@ -57,7 +57,7 @@ void registerOptions(Configurator* conf)
 PID launch(int numSlaves,
            int32_t cpus,
            int64_t mem,
-	   bool initLogging,
+           bool initLogging,
            bool quiet,
            bool dateInMasterId)
 {

--- a/src/local/local.cpp
+++ b/src/local/local.cpp
@@ -58,15 +58,13 @@ PID launch(int numSlaves,
            int32_t cpus,
            int64_t mem,
            bool initLogging,
-           bool quiet,
-           bool dateInMasterId)
+           bool quiet)
 {
   Params conf;
   conf.set("slaves", numSlaves);
   conf.set("cpus", cpus);
   conf.set("mem", mem);
   conf.set("quiet", quiet);
-  conf.set("date_in_master_id", dateInMasterId);
   return launch(conf, initLogging);
 }
 

--- a/src/local/local.cpp
+++ b/src/local/local.cpp
@@ -54,14 +54,19 @@ void registerOptions(Configurator* conf)
 }
 
 
-PID launch(int numSlaves, int32_t cpus, int64_t mem,
-	   bool initLogging, bool quiet)
+PID launch(int numSlaves,
+           int32_t cpus,
+           int64_t mem,
+	   bool initLogging,
+           bool quiet,
+           bool dateInMasterId)
 {
   Params conf;
   conf.set("slaves", numSlaves);
   conf.set("cpus", cpus);
   conf.set("mem", mem);
   conf.set("quiet", quiet);
+  conf.set("date_in_master_id", dateInMasterId);
   return launch(conf, initLogging);
 }
 

--- a/src/local/local.hpp
+++ b/src/local/local.hpp
@@ -14,14 +14,12 @@ void registerOptions(Configurator* conf);
 
 // Launch a local cluster with a given number of slaves and given numbers
 // of CPUs and memory per slave. Additionally one can also toggle whether
-// to initialize Google Logging, whether to log quietly, and whether to
-// include the date in master IDs (this is useful to disable for unit tests).
+// to initialize Google Logging and whether to log quietly.
 PID launch(int numSlaves,
            int32_t cpus,
            int64_t mem,
            bool initLogging,
-           bool quiet,
-           bool dateInMasterId = true);
+           bool quiet);
 
 // Launch a local cluster with a given configuration.
 PID launch(const Params& conf, bool initLogging);

--- a/src/local/local.hpp
+++ b/src/local/local.hpp
@@ -8,11 +8,22 @@
 
 namespace mesos { namespace internal { namespace local {
 
+// Register the options recognized by the local runner (a combination of
+// master and slave options) with a configurator.
 void registerOptions(Configurator* conf);
 
-PID launch(int numSlaves, int32_t cpus, int64_t mem,
-	   bool initLogging, bool quiet);
+// Launch a local cluster with a given number of slaves and given numbers
+// of CPUs and memory per slave. Additionally one can also toggle whether
+// to initialize Google Logging, whether to log quietly, and whether to
+// include the date in master IDs (this is useful to disable for unit tests).
+PID launch(int numSlaves,
+           int32_t cpus,
+           int64_t mem,
+	   bool initLogging,
+           bool quiet,
+           bool dateInMasterId = true);
 
+// Launch a local cluster with a given configuration.
 PID launch(const Params& conf, bool initLogging);
 
 void shutdown();

--- a/src/local/local.hpp
+++ b/src/local/local.hpp
@@ -19,7 +19,7 @@ void registerOptions(Configurator* conf);
 PID launch(int numSlaves,
            int32_t cpus,
            int64_t mem,
-	   bool initLogging,
+           bool initLogging,
            bool quiet,
            bool dateInMasterId = true);
 

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -2,6 +2,8 @@
 
 #include <glog/logging.h>
 
+#include "common/date_utils.hpp"
+
 #include "allocator.hpp"
 #include "allocator_factory.hpp"
 #include "master.hpp"
@@ -255,20 +257,14 @@ void Master::operator () ()
 {
   LOG(INFO) << "Master started at mesos://" << self();
 
-  // Don't do anything until we get a fault tolerance ID.
+  // Don't do anything until we get a master ID.
   while (receive() != GOT_MASTER_ID) {
     LOG(INFO) << "Oops! We're dropping a message since "
               << "we haven't received an identifier yet!";  
   }
+  string faultToleranceId;
   tie(faultToleranceId) = unpack<GOT_MASTER_ID>(body());
-
-  // Create a master ID based on the fault tolerance ID we got.
-  // We can optionally exclude the start date to simplify unit tests.
-  if (conf.get<bool>("date_in_master_id", true)) {
-    masterId = currentDate() + "-" + faultToleranceId;
-  } else {
-    masterId = faultToleranceId;
-  }
+  masterId = DateUtils::currentDate() + "-" + faultToleranceId;
   LOG(INFO) << "Master ID: " << masterId;
 
   // Create the allocator (we do this after the constructor because it
@@ -1133,19 +1129,6 @@ FrameworkID Master::newFrameworkId()
   ostringstream oss;
   oss << masterId << "-" << setw(4) << setfill('0') << fwId;
   return oss.str();
-}
-
-
-// Get the current date in the format used for master IDs (YYYYMMDDhhmm).
-string Master::currentDate()
-{
-  time_t rawtime;
-  struct tm* timeinfo;
-  time(&rawtime);
-  timeinfo = localtime(&rawtime);
-  char timestr[32];
-  strftime(timestr, sizeof(timestr), "%Y%m%d%H%M", timeinfo);
-  return timestr;
 }
 
 

--- a/src/master/master.hpp
+++ b/src/master/master.hpp
@@ -325,8 +325,12 @@ protected:
   string allocatorType;
   Allocator *allocator;
 
-  int64_t masterId; // Used to differentiate masters in fault tolerant mode;
-                    // will be this master's ZooKeeper ephemeral id
+  string faultToleranceId; // Differentiates masters in fault tolerant mode;
+                           // will be this master's ZooKeeper ephemeral id.
+ 
+  string masterId; // Contains the date the master was launched and its
+                   // faultToleranceId. Used in framework and slave IDs
+                   // created by this master.
 
 public:
   Master();
@@ -400,6 +404,8 @@ protected:
   virtual Allocator* createAllocator();
 
   FrameworkID newFrameworkId();
+
+  string currentDate();
 };
 
 

--- a/src/master/master.hpp
+++ b/src/master/master.hpp
@@ -325,12 +325,9 @@ protected:
   string allocatorType;
   Allocator *allocator;
 
-  string faultToleranceId; // Differentiates masters in fault tolerant mode;
-                           // will be this master's ZooKeeper ephemeral id.
- 
-  string masterId; // Contains the date the master was launched and its
-                   // faultToleranceId. Used in framework and slave IDs
-                   // created by this master.
+  string masterId; // Contains the date the master was launched and its fault
+                   // tolerance ID (e.g. ephemeral ID returned from ZooKeeper).
+                   // Used in framework and slave IDs created by this master.
 
 public:
   Master();

--- a/src/tests/test_master.cpp
+++ b/src/tests/test_master.cpp
@@ -5,6 +5,8 @@
 #include <mesos_exec.hpp>
 #include <mesos_sched.hpp>
 
+#include "common/date_utils.hpp"
+
 #include "local/local.hpp"
 
 #include "master/master.hpp"
@@ -75,7 +77,7 @@ public:
 TEST(MasterTest, NoopFrameworkWithOneSlave)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
   NoopScheduler sched(1);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
@@ -88,7 +90,7 @@ TEST(MasterTest, NoopFrameworkWithOneSlave)
 TEST(MasterTest, NoopFrameworkWithMultipleSlaves)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(10, 2, 1 * Gigabyte, false, false, false);
+  PID master = local::launch(10, 2, 1 * Gigabyte, false, false);
   NoopScheduler sched(10);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
@@ -132,130 +134,144 @@ public:
 TEST(MasterTest, DuplicateTaskIdsInResponse)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
   params["mem"] = lexical_cast<string>(1 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
-  tasks.push_back(TaskDescription(2, "0-0", "", params, ""));
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
+  tasks.push_back(TaskDescription(2, "200102030405-0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Duplicate task ID: 1", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, TooMuchMemoryInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
   params["mem"] = lexical_cast<string>(4 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Too many resources accepted", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, TooMuchCpuInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "4";
   params["mem"] = lexical_cast<string>(1 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Too many resources accepted", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, TooLittleCpuInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "0";
   params["mem"] = lexical_cast<string>(1 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Invalid task size: <0 CPUs, 1024 MEM>", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, TooLittleMemoryInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
   params["mem"] = "1";
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Invalid task size: <1 CPUs, 1 MEM>", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, TooMuchMemoryAcrossTasks)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
   params["mem"] = lexical_cast<string>(2 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
-  tasks.push_back(TaskDescription(2, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
+  tasks.push_back(TaskDescription(2, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Too many resources accepted", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, TooMuchCpuAcrossTasks)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "2";
   params["mem"] = lexical_cast<string>(1 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
-  tasks.push_back(TaskDescription(2, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
+  tasks.push_back(TaskDescription(2, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched(tasks);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
   EXPECT_EQ("Too many resources accepted", sched.errorMessage);
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
 TEST(MasterTest, ResourcesReofferedAfterReject)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(10, 2, 1 * Gigabyte, false, false, false);
+  PID master = local::launch(10, 2, 1 * Gigabyte, false, false);
 
   NoopScheduler sched1(10);
   MesosSchedulerDriver driver1(&sched1, master);
@@ -276,13 +292,14 @@ TEST(MasterTest, ResourcesReofferedAfterReject)
 TEST(MasterTest, ResourcesReofferedAfterBadResponse)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
+  DateUtils::setMockDate("200102030405");
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
 
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "0";
   params["mem"] = lexical_cast<string>(1 * Gigabyte);
-  tasks.push_back(TaskDescription(1, "0-0", "", params, ""));
+  tasks.push_back(TaskDescription(1, "200102030405-0-0", "", params, ""));
   FixedResponseScheduler sched1(tasks);
   MesosSchedulerDriver driver1(&sched1, master);
   driver1.run();
@@ -295,6 +312,7 @@ TEST(MasterTest, ResourcesReofferedAfterBadResponse)
   EXPECT_EQ(1, sched2.offersGotten);
 
   local::shutdown();
+  DateUtils::clearMockDate();
 }
 
 
@@ -414,7 +432,7 @@ TEST(MasterTest, SchedulerFailover)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
 
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
 
   FailoverScheduler failoverSched;
   FailingScheduler failingSched(&failoverSched, master);
@@ -548,7 +566,7 @@ TEST(MasterTest, SlavePartitioned)
 
   ProcessClock::pause();
 
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
 
   SlavePartitionedScheduler sched;
   MesosSchedulerDriver driver(&sched, master);

--- a/src/tests/test_master.cpp
+++ b/src/tests/test_master.cpp
@@ -75,7 +75,7 @@ public:
 TEST(MasterTest, NoopFrameworkWithOneSlave)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
   NoopScheduler sched(1);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
@@ -88,7 +88,7 @@ TEST(MasterTest, NoopFrameworkWithOneSlave)
 TEST(MasterTest, NoopFrameworkWithMultipleSlaves)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(10, 2, 1 * Gigabyte, false, false);
+  PID master = local::launch(10, 2, 1 * Gigabyte, false, false, false);
   NoopScheduler sched(10);
   MesosSchedulerDriver driver(&sched, master);
   driver.run();
@@ -132,7 +132,7 @@ public:
 TEST(MasterTest, DuplicateTaskIdsInResponse)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
@@ -151,7 +151,7 @@ TEST(MasterTest, DuplicateTaskIdsInResponse)
 TEST(MasterTest, TooMuchMemoryInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
@@ -168,7 +168,7 @@ TEST(MasterTest, TooMuchMemoryInTask)
 TEST(MasterTest, TooMuchCpuInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "4";
@@ -185,7 +185,7 @@ TEST(MasterTest, TooMuchCpuInTask)
 TEST(MasterTest, TooLittleCpuInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "0";
@@ -202,7 +202,7 @@ TEST(MasterTest, TooLittleCpuInTask)
 TEST(MasterTest, TooLittleMemoryInTask)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
@@ -219,7 +219,7 @@ TEST(MasterTest, TooLittleMemoryInTask)
 TEST(MasterTest, TooMuchMemoryAcrossTasks)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "1";
@@ -237,7 +237,7 @@ TEST(MasterTest, TooMuchMemoryAcrossTasks)
 TEST(MasterTest, TooMuchCpuAcrossTasks)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 3, 3 * Gigabyte, false, false);
+  PID master = local::launch(1, 3, 3 * Gigabyte, false, false, false);
   vector<TaskDescription> tasks;
   map<string, string> params;
   params["cpus"] = "2";
@@ -255,7 +255,7 @@ TEST(MasterTest, TooMuchCpuAcrossTasks)
 TEST(MasterTest, ResourcesReofferedAfterReject)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(10, 2, 1 * Gigabyte, false, false);
+  PID master = local::launch(10, 2, 1 * Gigabyte, false, false, false);
 
   NoopScheduler sched1(10);
   MesosSchedulerDriver driver1(&sched1, master);
@@ -276,7 +276,7 @@ TEST(MasterTest, ResourcesReofferedAfterReject)
 TEST(MasterTest, ResourcesReofferedAfterBadResponse)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
 
   vector<TaskDescription> tasks;
   map<string, string> params;
@@ -414,7 +414,7 @@ TEST(MasterTest, SchedulerFailover)
 {
   ASSERT_TRUE(GTEST_IS_THREADSAFE);
 
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
 
   FailoverScheduler failoverSched;
   FailingScheduler failingSched(&failoverSched, master);
@@ -548,7 +548,7 @@ TEST(MasterTest, SlavePartitioned)
 
   ProcessClock::pause();
 
-  PID master = local::launch(1, 2, 1 * Gigabyte, false, false);
+  PID master = local::launch(1, 2, 1 * Gigabyte, false, false, false);
 
   SlavePartitionedScheduler sched;
   MesosSchedulerDriver driver(&sched, master);


### PR DESCRIPTION
This commit adds the master start date into slave and framework IDs to make it easier to locate output from each framework. Before this, when ZooKeeper was not in use, slave IDs were just of the form 0-N, and each slave machine tended to have many slave IDs over time that could get reused. It was therefore hard to tell which directory to look in for output from a given framework. Now, the slave ID and framework ID both begin with a master ID that contains the master's start date as well as its ZooKeeper ephemeral ID. These makes the slave and framework IDs unique over time and correlated with each other (knowing a framework ID, I can figure out its slave ID on a given node, unless that node happens to have run multiple slaves).

To simplify testing, the local runner now also has an option to disable including the date in the master ID.
