### PR TITLE
Deploy script fixes

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -202,7 +202,7 @@ WEBUI_FILES = $(BINDIR)/webui/bottle-0.8.3		\
               $(BINDIR)/webui/static/stylesheet.css
 
 # We copy template config files into the conf directory.
-CONF_FILES = $(CONFDIR)/mesos.conf
+CONF_FILES = $(CONFDIR)/mesos.conf $(CONFDIR)/deploy-env.sh
 
 # We copy all the deploy scripts into the bin directory.
 DEPLOY_FILES = $(DEPLOYDIR)/deploy-to-slaves             \
@@ -334,6 +334,9 @@ $(DEPLOY_FILES): $(DEPLOYDIR)/%: @srcdir@/deploy/% | $(DEPLOYDIR)
 
 $(CONFDIR)/mesos.conf: | @srcdir@/conf/mesos.conf.template $(CONFDIR)
 	cp -r @srcdir@/conf/mesos.conf.template $@
+
+$(CONFDIR)/deploy-env.sh: | ./conf/deploy-env.sh.template $(CONFDIR)
+	cp -r ./conf/deploy-env.sh.template $@
 
 test: all
 	$(MAKE) -C tests test

--- a/src/conf/deploy-env.sh.template
+++ b/src/conf/deploy-env.sh.template
@@ -1,0 +1,14 @@
+#!/bin/bash
+# This file contains environment variables that should be set when starting a Mesos
+# daemon (master or slave) with the deploy scripts. It can be used to configure SSH
+# options or set which IP addresses the daemons should bind to, for example.
+
+# Options for SSH
+SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=2"
+
+# Set LIBPROCESS_IP to change the address to which the master and slaves bind
+# if the default address chosen by the system is not the right one. We include
+# two examples below that try to resolve the IP from the node's hostname.
+#LIBPROCESS_IP="hostname -i" #works on older versions of hostname, not on OS X
+#FULL_IP="hostname --all-ip-addresses" # newer versions of hostname only
+#export LIBPROCESS_IP=`echo $FULL_IP|sed 's/\([^ ]*\) .*/\1/'`

--- a/src/deploy/mesos-env.sh
+++ b/src/deploy/mesos-env.sh
@@ -35,12 +35,8 @@ fi
 # slave daemons as sudo.
 DEPLOY_WITH_SUDO=`$MESOS_HOME/bin/mesos-getconf deploy_with_sudo`
 
-# Options for SSH
-SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=2"
-
-# Set LIBPROCESS_IP to change the address to which the master and slaves bind
-# if the default address chosen by the system is not the right one. We include
-# two examples below that try to resolve the IP from the node's hostname.
-#LIBPROCESS_IP="hostname -i" #works on older versions of hostname, not on OS X
-#FULL_IP="hostname --all-ip-addresses" # newer versions of hostname only
-#export LIBPROCESS_IP=`echo $FULL_IP|sed 's/\([^ ]*\) .*/\1/'`
+# Read any user-configurable environment variables set in the deploy-env.sh file
+# in MESOS_HOME/conf, such as SSH options.
+if [ -e $MESOS_HOME/conf/deploy-env.sh ]; then
+  . $MESOS_HOME/conf/deploy-env.sh
+fi

--- a/src/deploy/mesos-env.sh
+++ b/src/deploy/mesos-env.sh
@@ -31,6 +31,10 @@ if [ "x$MESOS_URL" == "x" ]; then
   MESOS_URL="mesos://1@$FIRST_MASTER:5050"
 fi
 
+# Read the deploy_with_sudo config setting to determine whether to run
+# slave daemons as sudo.
+DEPLOY_WITH_SUDO=`$MESOS_HOME/bin/mesos-getconf deploy_with_sudo`
+
 # Options for SSH
 SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=2"
 

--- a/src/deploy/start-slaves
+++ b/src/deploy/start-slaves
@@ -5,11 +5,17 @@ DEPLOY_DIR=`cd "$DEPLOY_DIR"; pwd`
 
 cd $DEPLOY_DIR
 
+# Set SUDO_COMMAND to sudo if we should launch the slaves with sudo.
+SUDO_COMMAND=""
+if [ "$DEPLOY_WITH_SUDO" == "1" ]; then
+  SUDO_COMMAND="sudo"
+fi
+
 # Launch slaves
 for slave in $SLAVES; do
   echo "Starting slave on $slave"
-  echo ssh $SSH_OPTS $slave "$DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" 
-  ssh $SSH_OPTS $slave "$DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" &
+  echo ssh $SSH_OPTS $slave "$SUDO_COMMAND $DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" 
+  ssh $SSH_OPTS $slave "$SUDO_COMMAND $DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" &
   sleep 0.1
 done
 wait

--- a/src/deploy/start-slaves
+++ b/src/deploy/start-slaves
@@ -5,17 +5,17 @@ DEPLOY_DIR=`cd "$DEPLOY_DIR"; pwd`
 
 cd $DEPLOY_DIR
 
-# Set SUDO_COMMAND to sudo if we should launch the slaves with sudo.
-SUDO_COMMAND=""
+# Set OPTIONAL_SUDO_CMD to sudo if we should launch the slaves with sudo.
+OPTIONAL_SUDO_CMD=""
 if [ "$DEPLOY_WITH_SUDO" == "1" ]; then
-  SUDO_COMMAND="sudo"
+  OPTIONAL_SUDO_CMD="sudo"
 fi
 
 # Launch slaves
 for slave in $SLAVES; do
   echo "Starting slave on $slave"
-  echo ssh $SSH_OPTS $slave "$SUDO_COMMAND $DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" 
-  ssh $SSH_OPTS $slave "$SUDO_COMMAND $DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" &
+  echo ssh $SSH_OPTS $slave "$OPTIONAL_SUDO_CMD $DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" 
+  ssh $SSH_OPTS $slave "$OPTIONAL_SUDO_CMD $DEPLOY_DIR/mesos-daemon mesos-slave -u $MESOS_URL </dev/null >/dev/null" &
   sleep 0.1
 done
 wait

--- a/src/deploy/stop-slaves
+++ b/src/deploy/stop-slaves
@@ -6,16 +6,16 @@ DEPLOY_DIR=`cd "$DEPLOY_DIR"; pwd`
 
 cd $DEPLOY_DIR
 
-# Set SUDO_COMMAND to sudo if we launched the slave daemons with sudo,
+# Set OPTIONAL_SUDO_CMD to sudo if we launched the slave daemons with sudo,
 # so that we can kill them as sudo.
-SUDO_COMMAND=""
+OPTIONAL_SUDO_CMD=""
 if [ "$DEPLOY_WITH_SUDO" == "1" ]; then
-  SUDO_COMMAND="sudo"
+  OPTIONAL_SUDO_CMD="sudo"
 fi
 
 for slave in $SLAVES; do
   echo "Stopping slave on $slave"
-  ssh $SSH_OPTS $slave "$SUDO_COMMAND killall mesos-slave" &
+  ssh $SSH_OPTS $slave "$OPTIONAL_SUDO_CMD killall mesos-slave" &
   sleep 0.1
 done
 wait

--- a/src/deploy/stop-slaves
+++ b/src/deploy/stop-slaves
@@ -6,9 +6,16 @@ DEPLOY_DIR=`cd "$DEPLOY_DIR"; pwd`
 
 cd $DEPLOY_DIR
 
+# Set SUDO_COMMAND to sudo if we launched the slave daemons with sudo,
+# so that we can kill them as sudo.
+SUDO_COMMAND=""
+if [ "$DEPLOY_WITH_SUDO" == "1" ]; then
+  SUDO_COMMAND="sudo"
+fi
+
 for slave in $SLAVES; do
   echo "Stopping slave on $slave"
-  ssh $SSH_OPTS $slave "killall mesos-slave" &
+  ssh $SSH_OPTS $slave "$SUDO_COMMAND killall mesos-slave" &
   sleep 0.1
 done
 wait


### PR DESCRIPTION
This pull request contains two small fixes to the deploy scripts that were motivated by R cluster usage. The first is a flag for running the slaves as sudo, because on the R cluster, we want a regular user with passwordless sudo to run deploy/start-mesos and have the cluster come up. In the past, we were editing the deploy scripts manually to do this.

The second is moving user-configurable deploy options to conf/deploy-env.sh. In the past, these were in deploy/mesos-env.sh, but this file gets overwritten whenever you run make. It doesn't make sense to have both user-configurable stuff and Mesos code in this file, so I split the user-configurable stuff into its own file.
