### PR TITLE
Fixes issue 44

### DIFF
--- a/src/swig/mesos.i
+++ b/src/swig/mesos.i
@@ -543,6 +543,17 @@ jenv->ExceptionDescribe();
   %template(SlaveOfferVector) std::vector<mesos::SlaveOffer>;
   %template(TaskDescriptionVector) std::vector<mesos::TaskDescription>;
   %template(StringMap) std::map<std::string, std::string>;
+
+  %feature("director:except") {
+    if( $error != NULL ) {
+      PyObject *ptype, *pvalue, *ptraceback;
+      PyErr_Fetch( &ptype, &pvalue, &ptraceback );
+      PyErr_Restore( ptype, pvalue, ptraceback );
+      PyErr_Print();
+      Py_Exit(1);
+    }
+  }
+
 #endif /* SWIGPYTHON */
 
 /* Rename task_state enum so that the generated class is called TaskState */


### PR DESCRIPTION
This patch adds SWIG interface required to catch Python exceptions and to reports them. I hope, this simple fix handles all the cases. At least for the exceptions I tried out, it works. If there is something else I have missed out, please let me know. I will be happy to handle those cases. Otherwise, please pull these changes and close the issue #44.
