### PR TITLE
Use a random AZ as the default AZ when starting a mesos cluster in EC2

### DIFF
--- a/ec2/mesos_ec2.py
+++ b/ec2/mesos_ec2.py
@@ -6,6 +6,7 @@ from __future__ import with_statement
 import boto
 import logging
 import os
+import random
 import shutil
 import subprocess
 import sys
@@ -36,7 +37,7 @@ def parse_args():
            "WARNING: must be 64 bit, thus small instances won't work")
   parser.add_option("-m", "--master-instance-type", default="",
       help="Master instance type (leave empty for same as instance-type)")
-  parser.add_option("-z", "--zone", default="us-east-1b",
+  parser.add_option("-z", "--zone", default="",
       help="Availability zone to launch instances in")
   parser.add_option("-a", "--ami", default="ami-fa4eb393",
       help="Amazon Machine Image ID to use")
@@ -413,6 +414,10 @@ def ssh(host, opts, command):
 def main():
   (opts, action, cluster_name) = parse_args()
   conn = boto.connect_ec2()
+
+  # Select an AZ at random if it was not specified.
+  if opts.zone == "":
+    opts.zone = random.choice(conn.get_all_zones()).name
 
   if action == "launch":
     if opts.resume:


### PR DESCRIPTION
Hello,

This should close #162 which I opened up earlier today. It randomly selects an AZ when you run the script instead of using a hardcoded AZ as the default.

Thanks,
Dave 
