### PR TITLE
fixed dead links to mesos repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Please check out the source code from Apache's git:
   
     git clone git://git.apache.org/incubator-mesos.git
 
-or SVN:
-
-    svn checkout https://svn.apache.org/repos/asf/incubator/mesos/trunk
-
 or its GitHub mirror:
 
     git clone git://github.com/apache/incubator-mesos.git

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Mesos Has Moved!
 
-Mesos is now hosted in the [Apache incubator](http://incubator.apache.org/mesos).
+Mesos is now hosted in the [Apache incubator](http://incubator.apache.org/mesos). Here is [GitHub mirror](https://github.com/apache/incubator-mesos)
 
-The documentation can be [viewed via github here](https://github.com/apache/mesos/blob/trunk/docs/Home.md).
+The documentation can be [viewed via github here](https://github.com/apache/incubator-mesos/blob/master/docs/Home.md).
 
-Please check out the source code from Apache's SVN:
+Please check out the source code from Apache's git:
+  
+    git clone git://git.apache.org/incubator-mesos.git
+
+or SVN:
 
     svn checkout https://svn.apache.org/repos/asf/incubator/mesos/trunk
 
-or its Git mirror:
+or its GitHub mirror:
 
-    git clone git://github.com/apache/mesos.git
+    git clone git://github.com/apache/incubator-mesos.git
 
 For issue tracking, please use the [JIRA issue tracker](https://issues.apache.org/jira/browse/MESOS) instead of the GitHub one.
 


### PR DESCRIPTION
Updated dead links to point to new git repository at apache (and it's github mirror)
