### PR TITLE
Added docker::killAndRm() to performs 'docker kill && docker rm (-f)'

### DIFF
--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -115,7 +115,9 @@ Future<Option<int> > Docker::kill(const string& container) const
 }
 
 
-Future<Option<int> > Docker::rm(const string& container, const bool force) const
+Future<Option<int> > Docker::rm(
+    const string& container,
+    const bool force) const
 {
   string cmd = force ? " rm -f " : " rm ";
 
@@ -132,6 +134,26 @@ Future<Option<int> > Docker::rm(const string& container, const bool force) const
   }
 
   return s.get().status();
+}
+
+
+Future<Option<int> > Docker::killAndRm(const string& container) const
+{
+  return kill(container)
+    .then(lambda::bind(Docker::_killAndRm, *this, container, lambda::_1));
+}
+
+
+Future<Option<int> > Docker::_killAndRm(
+    const Docker& docker,
+    const string& container,
+    const Option<int>& status)
+{
+  // If 'kill' fails, then do a 'rm -f'.
+  if (status.isNone()) {
+    return docker.rm(container, true);
+  }
+  return docker.rm(container);
 }
 
 
@@ -258,7 +280,7 @@ Future<list<Docker::Container> > Docker::ps(const bool all) const
   }
 
   return s.get().status()
-    .then(lambda::bind(&Docker::_ps, Docker(path), s.get()));
+    .then(lambda::bind(&Docker::_ps, *this, s.get()));
 }
 
 

--- a/src/docker/docker.hpp
+++ b/src/docker/docker.hpp
@@ -73,6 +73,14 @@ public:
       const std::string& container,
       const bool force = false) const;
 
+  // Performs 'docker kill && docker rm'
+  // if 'docker kill' fails, then will do a 'docker rm -f'.
+  //
+  // TODO(yifan): Depreciate this when the docker provides
+  // something like 'docker rm --kill'.
+  process::Future<Option<int> > killAndRm(
+      const std::string& container) const;
+
   // Performs 'docker inspect CONTAINER'.
   process::Future<Container> inspect(
       const std::string& container) const;
@@ -90,6 +98,10 @@ private:
   static process::Future<std::list<Container> > _ps(
       const Docker& docker,
       const process::Subprocess& s);
+  static process::Future<Option<int> > _killAndRm(
+      const Docker& docker,
+      const std::string& container,
+      const Option<int>& status);
 
   const std::string path;
 };

--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -438,7 +438,7 @@ Future<Nothing> DockerContainerizerProcess::_recover(
     if (!statuses.keys().contains(id.get())) {
       // TODO(benh): Retry 'docker rm -f' if it failed but the container
       // still exists (asynchronously).
-      docker.rm(container.id(), true);
+      docker.killAndRm(container.id());
     }
   }
 
@@ -706,7 +706,7 @@ void DockerContainerizerProcess::destroy(
 
   // TODO(benh): Retry 'docker rm -f' if it failed but the container
   // still exists (asynchronously).
-  docker.rm(DOCKER_NAME_PREFIX + stringify(containerId), true)
+  docker.killAndRm(DOCKER_NAME_PREFIX + stringify(containerId))
     .onAny(defer(self(), &Self::_destroy, containerId, killed, lambda::_1));
 }
 


### PR DESCRIPTION
This will be faster than doing 'docker rm -f' on a running container.
